### PR TITLE
feat: add LM Studio backend support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-05-18
+
+### Added
+- LM Studio backend support (`-s, --lmstudio`) via the translation proxy
+
 ## [0.4.0] - 2026-03-02
 
 ### Added
@@ -56,7 +61,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Model picker with search
 - Config persistence
 
-[Unreleased]: https://github.com/paddo/claude-launcher/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/paddo/claude-launcher/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/paddo/claude-launcher/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/paddo/claude-launcher/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/paddo/claude-launcher/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/paddo/claude-launcher/compare/v0.1.1...v0.2.0

--- a/README.md
+++ b/README.md
@@ -3,16 +3,17 @@
 [![npm version](https://img.shields.io/npm/v/claude-launcher)](https://www.npmjs.com/package/claude-launcher)
 [![license](https://img.shields.io/npm/l/claude-launcher)](LICENSE)
 
-Launch Claude Code with multiple backends (Anthropic, OpenRouter).
+Launch Claude Code with multiple backends (Anthropic, OpenRouter, Ollama, NVIDIA NIM, LM Studio).
 
 ## Features
 
-- **OpenRouter integration** - use any model via OpenRouter
+- **Multiple backends** - Anthropic, OpenRouter, Ollama, NVIDIA NIM, LM Studio
 - **OAuth login** - authenticate with `claude-launcher login`
 - **Model picker** - searchable model selection
 - **Exacto support** - auto-uses `:exacto` variants for better tool calling
 - **Role models** - configure different models for sonnet/opus/haiku tasks
 - **New model alerts** - notifies when new models are available
+- **Local backends** - run fully offline via Ollama or LM Studio
 
 ## Install
 
@@ -34,17 +35,30 @@ Requires [Claude Code](https://docs.anthropic.com/en/docs/claude-code) installed
 claude-launcher                    # launch with saved settings
 claude-launcher login              # authenticate with OpenRouter
 claude-launcher logout             # clear stored credentials
-claude-launcher -m                 # pick a model
-claude-launcher -o                 # use OpenRouter backend
+claude-launcher -b                 # pick backend and model
 claude-launcher -a                 # use Anthropic backend
+claude-launcher -o                 # use OpenRouter backend
+claude-launcher -l                 # use Ollama backend (local)
+claude-launcher -n                 # use NVIDIA NIM backend
+claude-launcher -s                 # use LM Studio backend (local)
 claude-launcher -- --resume        # pass args to claude
 ```
 
+## Backends
+
+- **Anthropic** - standard Claude Code, no extra config
+- **OpenRouter** - any model via OpenRouter; OAuth login or `OPENROUTER_API_KEY`
+- **Ollama** - local models, auto-filtered to tool-capable ones
+- **NVIDIA NIM** - cloud (`NVIDIA_API_KEY`) or self-hosted endpoints
+- **LM Studio** - local models via the LM Studio server (host must include `/v1`, e.g. `http://localhost:1234/v1`)
+
+NIM and LM Studio run through an in-process Anthropic-to-OpenAI translation proxy.
+
 ## First Run
 
-1. Run `claude-launcher`
-2. Select backend (Anthropic or OpenRouter)
-3. If OpenRouter: login or use existing `OPENROUTER_API_KEY`
+1. Run `claude-launcher -b`
+2. Select a backend
+3. Provide credentials if the backend needs them
 4. Pick a model
 5. Optionally configure role models (sonnet/opus/haiku)
 
@@ -58,6 +72,7 @@ Settings stored at `~/.config/claude-launcher/config.json`:
 ## Environment Variables
 
 - `OPENROUTER_API_KEY` - fallback if not logged in via OAuth
+- `NVIDIA_API_KEY` - NIM cloud API key
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-launcher",
-  "version": "0.4.0",
-  "description": "Launch Claude Code with multiple backends (Anthropic, OpenRouter, Ollama)",
+  "version": "0.5.0",
+  "description": "Launch Claude Code with multiple backends (Anthropic, OpenRouter, Ollama, NVIDIA NIM, LM Studio)",
   "type": "module",
   "bin": {
     "claude-launcher": "./dist/index.js"

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,7 @@ import { homedir } from "os";
 import { join } from "path";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 
-export type Backend = "anthropic" | "openrouter" | "ollama" | "nim";
+export type Backend = "anthropic" | "openrouter" | "ollama" | "nim" | "lmstudio";
 
 export interface Config {
   backend?: Backend;
@@ -24,6 +24,11 @@ export interface Config {
   nimSonnetModel?: string;
   nimOpusModel?: string;
   nimHaikuModel?: string;
+  lmstudioHost?: string;
+  lmstudioModel?: string;
+  lmstudioSonnetModel?: string;
+  lmstudioOpusModel?: string;
+  lmstudioHaikuModel?: string;
 }
 
 const CONFIG_DIR = join(homedir(), ".config", "claude-launcher");

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,8 @@
 import { spawn } from "child_process";
 import { confirm, input } from "@inquirer/prompts";
 import { getConfig, saveConfig, type Backend } from "./config";
-import { fetchModels, filterAgenticModels, getNewModels, fetchOllamaModels, filterToolCapableOllamaModels, fetchNimModels } from "./models";
-import { pickBackend, pickModel, pickOllamaModel, pickNimModel } from "./picker";
+import { fetchModels, filterAgenticModels, getNewModels, fetchOllamaModels, filterToolCapableOllamaModels, fetchOpenAIModels } from "./models";
+import { pickBackend, pickModel, pickOllamaModel, pickOpenAIModel } from "./picker";
 import { login } from "./auth";
 import { startProxy } from "./proxy";
 
@@ -15,6 +15,7 @@ function parseArgs() {
     anthropic: false,
     ollama: false,
     nim: false,
+    lmstudio: false,
     backend: false,
     help: false,
     login: false,
@@ -36,6 +37,8 @@ function parseArgs() {
       flags.ollama = true;
     } else if (arg === "--nim" || arg === "-n") {
       flags.nim = true;
+    } else if (arg === "--lmstudio" || arg === "-s") {
+      flags.lmstudio = true;
     } else if (arg === "--backend" || arg === "-b" || arg === "--model" || arg === "-m") {
       flags.backend = true;
     } else if (arg === "--help" || arg === "-h") {
@@ -52,9 +55,12 @@ function parseArgs() {
   return { flags, passthrough };
 }
 
-function launchClaude(passthrough: string[], env?: NodeJS.ProcessEnv) {
+function launchClaude(passthrough: string[], env?: NodeJS.ProcessEnv, onExit?: () => void) {
   const child = spawn("claude", passthrough, { env, stdio: "inherit" });
-  child.on("exit", (code) => process.exit(code || 0));
+  child.on("exit", (code) => {
+    onExit?.();
+    process.exit(code || 0);
+  });
 }
 
 function showHelp() {
@@ -73,6 +79,7 @@ Options:
   -a, --anthropic   Use Anthropic backend
   -l, --ollama      Use Ollama backend (local)
   -n, --nim         Use NVIDIA NIM backend
+  -s, --lmstudio    Use LM Studio backend (local)
   -h, --help        Show this help
 
 Examples:
@@ -81,6 +88,7 @@ Examples:
   claude-launcher -b                 # pick backend and model
   claude-launcher -l                 # use Ollama local backend
   claude-launcher -n                 # use NVIDIA NIM backend
+  claude-launcher -s                 # use LM Studio local backend
   claude-launcher -- --resume        # pass args to claude`);
 }
 
@@ -128,6 +136,8 @@ async function main() {
     backend = "ollama";
   } else if (flags.nim) {
     backend = "nim";
+  } else if (flags.lmstudio) {
+    backend = "lmstudio";
   } else if (config.backend) {
     backend = config.backend;
   } else {
@@ -305,7 +315,7 @@ async function main() {
     }
 
     console.log("Fetching NIM models...");
-    const models = await fetchNimModels(host, apiKey !== "not-used" ? apiKey : undefined);
+    const models = await fetchOpenAIModels(host, apiKey !== "not-used" ? apiKey : undefined);
 
     if (models.length === 0) {
       console.error("No models found on NIM endpoint.");
@@ -314,7 +324,7 @@ async function main() {
 
     let nimModel = config.nimModel;
     if (flags.backend || !nimModel || !models.some((m) => m.id === nimModel)) {
-      nimModel = await pickNimModel(models);
+      nimModel = await pickOpenAIModel(models);
       config.nimModel = nimModel;
       config.backend = "nim";
 
@@ -324,9 +334,9 @@ async function main() {
       });
 
       if (configureRoles) {
-        config.nimSonnetModel = await pickNimModel(models, "Sonnet (lighter tasks)");
-        config.nimOpusModel = await pickNimModel(models, "Opus (complex tasks)");
-        config.nimHaikuModel = await pickNimModel(models, "Haiku (quick/cheap)");
+        config.nimSonnetModel = await pickOpenAIModel(models, "Sonnet (lighter tasks)");
+        config.nimOpusModel = await pickOpenAIModel(models, "Opus (complex tasks)");
+        config.nimHaikuModel = await pickOpenAIModel(models, "Haiku (quick/cheap)");
       }
 
       saveConfig(config);
@@ -346,11 +356,61 @@ async function main() {
     };
 
     console.log(`\nLaunching claude with ${nimModel} (NIM via proxy :${proxy.port})...\n`);
-    const child = spawn("claude", passthrough, { env, stdio: "inherit" });
-    child.on("exit", (code) => {
-      proxy.close();
-      process.exit(code || 0);
-    });
+    launchClaude(passthrough, env, () => proxy.close());
+  } else if (backend === "lmstudio") {
+    const host = config.lmstudioHost || "http://localhost:1234/v1";
+
+    console.log("Fetching LM Studio models...");
+    let models;
+    try {
+      models = await fetchOpenAIModels(host);
+    } catch {
+      console.error(`Failed to connect to LM Studio at ${host}`);
+      console.error("Make sure the LM Studio server is running.");
+      process.exit(1);
+    }
+
+    if (models.length === 0) {
+      console.error("No models found. Load a model in LM Studio first.");
+      process.exit(1);
+    }
+
+    let lmstudioModel = config.lmstudioModel;
+    if (flags.backend || !lmstudioModel || !models.some((m) => m.id === lmstudioModel)) {
+      lmstudioModel = await pickOpenAIModel(models);
+      config.lmstudioModel = lmstudioModel;
+      config.backend = "lmstudio";
+
+      const configureRoles = await confirm({
+        message: "Configure role models? (ensures all requests stay local)",
+        default: true,
+      });
+
+      if (configureRoles) {
+        config.lmstudioSonnetModel = await pickOpenAIModel(models, "Sonnet (lighter tasks)");
+        config.lmstudioOpusModel = await pickOpenAIModel(models, "Opus (complex tasks)");
+        config.lmstudioHaikuModel = await pickOpenAIModel(models, "Haiku (quick/cheap)");
+      }
+
+      saveConfig(config);
+    }
+
+    console.log("Starting proxy...");
+    const proxy = await startProxy(host);
+
+    const env = {
+      ...process.env,
+      ANTHROPIC_BASE_URL: `http://127.0.0.1:${proxy.port}`,
+      ANTHROPIC_API_KEY: "",
+      ANTHROPIC_AUTH_TOKEN: "lmstudio",
+      ANTHROPIC_MODEL: lmstudioModel,
+      ANTHROPIC_DEFAULT_SONNET_MODEL: config.lmstudioSonnetModel || lmstudioModel,
+      ANTHROPIC_DEFAULT_OPUS_MODEL: config.lmstudioOpusModel || lmstudioModel,
+      ANTHROPIC_DEFAULT_HAIKU_MODEL: config.lmstudioHaikuModel || lmstudioModel,
+    };
+
+    console.log(`\nLaunching claude with ${lmstudioModel} (LM Studio via proxy :${proxy.port})...\n`);
+    launchClaude(passthrough, env, () => proxy.close());
   } else {
     // Anthropic - just launch claude
     console.log("Launching claude...\n");

--- a/src/models.ts
+++ b/src/models.ts
@@ -66,21 +66,21 @@ export async function filterToolCapableOllamaModels(
   return results.filter((r) => r.hasTools).map((r) => r.model);
 }
 
-export interface NimModel {
+export interface OpenAIModel {
   id: string;
   object: string;
 }
 
-interface NimModelsResponse {
-  data: NimModel[];
+interface OpenAIModelsResponse {
+  data: OpenAIModel[];
 }
 
-export async function fetchNimModels(host: string, apiKey?: string): Promise<NimModel[]> {
+export async function fetchOpenAIModels(host: string, apiKey?: string): Promise<OpenAIModel[]> {
   const headers: Record<string, string> = {};
   if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
   const res = await fetch(`${host}/models`, { headers });
-  if (!res.ok) throw new Error(`Failed to fetch NIM models: ${res.status}`);
-  const data = (await res.json()) as NimModelsResponse;
+  if (!res.ok) throw new Error(`Failed to fetch models: ${res.status}`);
+  const data = (await res.json()) as OpenAIModelsResponse;
   return data.data || [];
 }
 

--- a/src/picker.ts
+++ b/src/picker.ts
@@ -1,5 +1,5 @@
 import { search, select } from "@inquirer/prompts";
-import type { OpenRouterModel, OllamaModel, NimModel } from "./models";
+import type { OpenRouterModel, OllamaModel, OpenAIModel } from "./models";
 import { formatContext, formatPrice, formatOllamaSize } from "./models";
 import type { Backend } from "./config";
 
@@ -12,6 +12,7 @@ export async function pickBackend(defaultValue?: Backend): Promise<Backend> {
       { name: "OpenRouter (multiple models)", value: "openrouter" as Backend },
       { name: "Ollama (local)", value: "ollama" as Backend },
       { name: "NIM (NVIDIA)", value: "nim" as Backend },
+      { name: "LM Studio (local)", value: "lmstudio" as Backend },
     ],
   });
 }
@@ -41,14 +42,14 @@ export async function pickModel(
   });
 }
 
-export async function pickNimModel(models: NimModel[], label?: string): Promise<string> {
+export async function pickOpenAIModel(models: OpenAIModel[], label?: string): Promise<string> {
   const choices = models.map((m) => ({
     name: m.id,
     value: m.id,
   }));
 
   return select({
-    message: label ? `${label}:` : "Select NIM model:",
+    message: label ? `${label}:` : "Select model:",
     choices,
   });
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -407,7 +407,7 @@ async function readBody(req: IncomingMessage): Promise<string> {
   return Buffer.concat(chunks).toString();
 }
 
-export async function startProxy(nimHost: string, apiKey: string): Promise<{ port: number; close: () => void }> {
+export async function startProxy(host: string, apiKey?: string): Promise<{ port: number; close: () => void }> {
   return new Promise((resolve) => {
     const server = createServer(async (req, res) => {
       // Only handle POST /v1/messages
@@ -427,7 +427,7 @@ export async function startProxy(nimHost: string, apiKey: string): Promise<{ por
         };
         if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
 
-        const upstream = await fetch(`${nimHost}/chat/completions`, {
+        const upstream = await fetch(`${host}/chat/completions`, {
           method: "POST",
           headers,
           body: JSON.stringify(openaiReq),


### PR DESCRIPTION
Adds LM Studio as a backend.

LM Studio exposes an OpenAI-compatible API, so the existing NIM model
fetch/pick helpers are generalized (`fetchOpenAIModels`, `pickOpenAIModel`)
rather than duplicated, and LM Studio routes through the existing
Anthropic-to-OpenAI translation proxy.

- `--lmstudio` / `-s` flag and interactive backend selection
- default host `http://localhost:1234/v1`, no API key required
- role model configuration, defaulting on (keeps all requests local)
- version bump to 0.5.0, changelog and README updated